### PR TITLE
added tsconfig file for compiling the lambda code

### DIFF
--- a/feedback-elicitation/examples/WeatherBot/tsconfig.json
+++ b/feedback-elicitation/examples/WeatherBot/tsconfig.json
@@ -1,0 +1,41 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "es6",
+        "lib": [
+            "es2018",
+            "es2015.promise",
+            "dom"
+        ],
+        "typeRoots": [
+            "./node_modules/@types"
+        ],
+        "declaration": true,
+        "outDir": "./dist",
+        "strict": true,
+        "alwaysStrict": true,
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "strictNullChecks": true,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "moduleResolution": "node",
+        "jsx": "react",
+        "downlevelIteration": true
+    },
+    "exclude": [
+        "test",
+        "build"
+    ],
+    "include": [
+        "lambda/*"
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The WeatherBot example skill's lambda code was failing to compile because of the absence of tsconfig.json file. So added the tsconfig.json file to the root of the example skill.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
