### PR TITLE
Fixed an error in types

### DIFF
--- a/list-navigation/src/types.acdl
+++ b/list-navigation/src/types.acdl
@@ -61,7 +61,7 @@ type PaginationConfig<Item> {
     Event<Nothing> nextEvent
     Event<Nothing> prevEvent
 
-    Action2<ListReference<Item>, Optional<String>, Page<Item>> getPageApi
+    Action2<ListReference, Optional<String>, Page<Item>> getPageApi
 
     Response presentPageResponse
 }
@@ -74,7 +74,7 @@ type SelectionConfig<Item, ItemName> {
     Event<ItemNameSlotWrapper<ItemName>> selectByNameEvent
     Event<Nothing> selectRandomlyEvent
 
-    Action3<ListReference<Item>, Page<Item>, ItemName, NUMBER> indexOfByNameApi
+    Action3<ListReference, Page<Item>, ItemName, NUMBER> indexOfByNameApi
 
-    Action3<ListReference<Item>, Page<Item>, NUMBER, Item> selectItemApi
+    Action3<ListReference, Page<Item>, NUMBER, Item> selectItemApi
 }


### PR DESCRIPTION
Fixed an overlooked error in types.acdl, that may cause builds to fail.

`ListReference` had a generic argument `Item` in `PaginationConfig` and `SelectionConfig`, but it shouldn't have one by definition. 
```
type ListReference {
    String id
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
