### PR TITLE
Maintaining a selectedItem in session args, added getSelectedItem met…

### DIFF
--- a/list-navigation/lambda/handlers/select-item.ts
+++ b/list-navigation/lambda/handlers/select-item.ts
@@ -41,9 +41,12 @@ export class SelectItemHandler extends BaseApiHandler {
     async handle(handlerInput : HandlerInput): Promise<Response>{
         const args = util.getApiArguments(handlerInput) as Arguments;
 
+        let sessionState: ListNavSessionState;
+
         let currentPage: Page<any>;
+
         if (ListNav.useSessionArgs) {
-            const sessionState = ListNavSessionState.load(handlerInput);
+            sessionState = ListNavSessionState.load(handlerInput);
             currentPage = await sessionState.getCurrentPage();
             sessionState.validateArguments(args.listRef, args.page.pageToken);
         } 
@@ -52,6 +55,11 @@ export class SelectItemHandler extends BaseApiHandler {
         }
         
         const selectedItem = currentPage.items[args.index-1];
+
+        if (ListNav.useSessionArgs){
+            sessionState!.argsState!.selectedItem = selectedItem;
+            sessionState!.save(handlerInput);
+        }
 
         return handlerInput.responseBuilder
             .withApiResponse(selectedItem)

--- a/list-navigation/lambda/interface.ts
+++ b/list-navigation/lambda/interface.ts
@@ -96,6 +96,14 @@ export class ListNav {
         }
     }
 
+    static getSelectedItem(handlerInput: HandlerInput): any{
+        if (ListNav.useSessionArgs){
+            const sessionState = ListNavSessionState.load(handlerInput);
+            const selectedItem = sessionState.argsState?.selectedItem;
+            return selectedItem;
+        }
+    }
+
     // get the list provider instance for a list reference; reconstructs the list provider instance from
     // serialized state in the list reference object
     //

--- a/list-navigation/lambda/session-state.ts
+++ b/list-navigation/lambda/session-state.ts
@@ -47,6 +47,8 @@ export interface ArgumentsState{
     // current paging direction; set by record-event APIs; used by getPage API
     pagingDirection?: PagingDirection;
 
+    // current selected item
+    selectedItem?: any;
 }
 
 export class ListNavSessionState {


### PR DESCRIPTION
…hod.

*Description of changes:*
Maintaining `selectedItem` in session args now. Added getSelectedItem method, to access the selected item directly from session.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
